### PR TITLE
feat: add coverage support to Storybook and update dependencies

### DIFF
--- a/libs/shared/ui/.storybook/main.ts
+++ b/libs/shared/ui/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/angular';
 
 const config: StorybookConfig = {
   stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions', '@storybook/addon-coverage'],
   framework: {
     name: '@storybook/angular',
     options: {},

--- a/libs/shared/ui/project.json
+++ b/libs/shared/ui/project.json
@@ -66,7 +66,7 @@
     "test-storybook": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "test-storybook -c libs/shared/ui/.storybook --url=http://localhost:4400"
+        "command": "test-storybook -c libs/shared/ui/.storybook --url=http://localhost:4400 --coverage"
       }
     },
     "static-storybook": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@nx/workspace": "21.1.0",
         "@playwright/test": "^1.36.0",
         "@schematics/angular": "19.2.9",
+        "@storybook/addon-coverage": "1.0.5",
         "@storybook/addon-essentials": "8.6.14",
         "@storybook/addon-interactions": "8.6.14",
         "@storybook/angular": "8.6.14",
@@ -64,9 +65,11 @@
         "angular-eslint": "19.4.0",
         "autoprefixer": "^10.4.0",
         "chromatic": "^11.16.1",
+        "concurrently": "9.1.2",
         "eslint": "^9.8.0",
         "eslint-config-prettier": "10.1.5",
         "eslint-plugin-playwright": "^1.6.2",
+        "http-server": "14.1.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-preset-angular": "14.4.2",
@@ -85,7 +88,8 @@
         "ts-node": "10.9.1",
         "tslib": "^2.3.0",
         "typescript": "5.7.3",
-        "typescript-eslint": "^8.13.0"
+        "typescript-eslint": "^8.13.0",
+        "wait-on": "8.0.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4503,12 +4507,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.25.tgz",
-      "integrity": "sha512-YKUYnvrxXBRhH/iYEwSOv85VPvc6P36GW1OCDRebTw/cvgoj7pwac2nZKYFs5FHlNYe7Bc9I4BoY2X0vlkJo+g==",
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.26.tgz",
+      "integrity": "sha512-4baB7tR0KukyGzrlD25aeO4t0ChLifwvDQXTBiVJE9WWwJEOjkZpHmoU9Iww0+Vdalsq4sZ3abp6YTNjHyB1dA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.10.5",
+        "@firebase/auth": "1.10.6",
         "@firebase/auth-types": "0.13.0",
         "@firebase/component": "0.6.17",
         "@firebase/util": "1.12.0",
@@ -4522,9 +4526,9 @@
       }
     },
     "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.5.tgz",
-      "integrity": "sha512-6wF/NdMTwObL4RNQePunuzMr9O3gyftisvFZFFKf57D2HONXo87YymogRV8d+Z7SLA0rcNBN1gLJVk2D0y97gA==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.6.tgz",
+      "integrity": "sha512-cFbo2FymQltog4atI9cKTO6CxKxS0dOMXslTQrlNZRH7qhDG44/d7QeI6GXLweFZtrnlecf52ESnNz1DU6ek8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -4575,9 +4579,9 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.8.tgz",
-      "integrity": "sha512-xC50SxurrP0j9ksltZ8O2SuPuWTu9KymNxtSE4bmcc/HMOnOHaURgLyrQpcC5Pc7HmtCBxh9Q/lNKyc37rj5/g==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.9.tgz",
+      "integrity": "sha512-B5tGEh5uQrQeH0i7RvlU8kbZrKOJUmoyxVIX4zLA8qQJIN6A7D+kfBlGXtSwbPdrvyaejcRPcbOtqsDQ9HPJKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/auth-interop-types": "0.2.4",
@@ -4591,9 +4595,9 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.18.tgz",
-      "integrity": "sha512-uXtYQmK6JCmqSx7dTOQD/qZtSnbMqnwvklF9n7wOJbdti4wKHmeUzgGXhPwDhN/R/BDTq78zKAbXya7hrCQjHw==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.19.tgz",
+      "integrity": "sha512-khE+MIYK+XlIndVn/7mAQ9F1fwG5JHrGKaG72hblCC6JAlUBDd3SirICH6SMCf2PQ0iYkruTECth+cRhauacyQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
@@ -4609,13 +4613,13 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.9.tgz",
-      "integrity": "sha512-9S6zK5+Tzslkt+lrYHDqbCbKBSQn3YYrNLIw8hTa/ALoqRLNTXF6acQIlxAxSeZj1hTttE6RRbuxxpMQJYt83w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.10.tgz",
+      "integrity": "sha512-3sjl6oGaDDYJw/Ny0E5bO6v+KM3KoD4Qo/sAfHGdRFmcJ4QnfxOX9RbG9+ce/evI3m64mkPr24LlmTDduqMpog==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
-        "@firebase/database": "1.0.18",
+        "@firebase/database": "1.0.19",
         "@firebase/database-types": "1.0.14",
         "@firebase/logger": "0.4.4",
         "@firebase/util": "1.12.0",
@@ -4636,9 +4640,9 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.7.15",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.15.tgz",
-      "integrity": "sha512-FgWTmkNBEXdKCoN2ngBNjrMaXuBx6QwjiZZVnOGg+VjUmiBq5gAqlDIW5bZY6i/NYvLUrWugdqIs7y9GHEqwww==",
+      "version": "4.7.16",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.16.tgz",
+      "integrity": "sha512-5OpvlwYVUTLEnqewOlXmtIpH8t2ISlZHDW0NDbKROM2D0ATMqFkMHdvl+/wz9zOAcb8GMQYlhCihOnVAliUbpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -4657,13 +4661,13 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.50",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.50.tgz",
-      "integrity": "sha512-1hAM+iaIqy2HHvSHQ56ccOOIigTeWAwjIpeQ+/O92uBoiajEITHdJofnGHglhhB5VV5qFl59Yz/AVDc+DssdYg==",
+      "version": "0.3.51",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.51.tgz",
+      "integrity": "sha512-E5iubPhS6aAM7oSsHMx/FGBwfA2nbEHaK/hCs+MD3l3N7rHKnq4SYCGmVu/AraSJaMndZR1I37N9A/BH7aCq5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
-        "@firebase/firestore": "4.7.15",
+        "@firebase/firestore": "4.7.16",
         "@firebase/firestore-types": "3.0.3",
         "@firebase/util": "1.12.0",
         "tslib": "^2.1.0"
@@ -4686,9 +4690,9 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.7.tgz",
-      "integrity": "sha512-gi8cw7yvaz19Erut+S0rHzNOWp4zPxAU/Kplb+XQoaE5gMV7MjHQoOGnYhSY8uOVj5f80S553s+2OBszG+14Ag==",
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.8.tgz",
+      "integrity": "sha512-p+ft6dQW0CJ3BLLxeDb5Hwk9ARw01kHTZjLqiUdPRzycR6w7Z75ThkegNmL6gCss3S0JEpldgvehgZ3kHybVhA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
@@ -4706,13 +4710,13 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.24.tgz",
-      "integrity": "sha512-UjJabci+Bqci+A9WqfJ6sjZp+wGvi47llnQMjQRrF4coKfUyu9zBNTXhbx5W3rdVFQYwnWJm8VuluuNh2PCuyQ==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.25.tgz",
+      "integrity": "sha512-V0JKUw5W/7aznXf9BQ8LIYHCX6zVCM8Hdw7XUQ/LU1Y9TVP8WKRCnPB/qdPJ0xGjWWn7fhtwIYbgEw/syH4yTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
-        "@firebase/functions": "0.12.7",
+        "@firebase/functions": "0.12.8",
         "@firebase/functions-types": "0.6.3",
         "@firebase/util": "1.12.0",
         "tslib": "^2.1.0"
@@ -4900,9 +4904,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/storage": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.11.tgz",
-      "integrity": "sha512-nBtCGGpr39vuAeTQhG73nvMq3BjQBTgIg6fWufB6qglWYQCgky/XE4duSrOhTp2/QC+H3/SnaE/nKOQmjnPqjg==",
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.12.tgz",
+      "integrity": "sha512-5JmoFS01MYjW1XMQa5F5rD/kvMwBN10QF03bmcuJWq4lg+BJ3nRgL3sscWnyJPhwM/ZCyv2eRwcfzESVmsYkdQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -4917,13 +4921,13 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.21.tgz",
-      "integrity": "sha512-LG3978H2Vy1XGa0Jz9VNFwgMrhjy/G8CTV8GkWpArzu+AhI/SE9c0e06SiXcFsVaQW2rObcqFa0zp51LDaVzRA==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.22.tgz",
+      "integrity": "sha512-29j6JgXTjQ76sOIkxmTNHQfYA/hDTeV9qGbn0jolynPXSg/AmzCB0CpCoCYrS0ja0Flgmy1hkA3XYDZ/eiV1Cg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
-        "@firebase/storage": "0.13.11",
+        "@firebase/storage": "0.13.12",
         "@firebase/storage-types": "0.8.3",
         "@firebase/util": "1.12.0",
         "tslib": "^2.1.0"
@@ -6088,6 +6092,114 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/coverage-istanbul-loader/-/coverage-istanbul-loader-3.0.5.tgz",
+      "integrity": "sha512-EUCPEkaRPvmHjWAAZkWMT7JDzpw7FKB00WTISaiXsbNOd5hCHg77XLA8sLYLFDo1zepYLo2w7GstN8YBqRXZfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-source-map": "^1.7.0",
+        "istanbul-lib-instrument": "^4.0.3",
+        "loader-utils": "^2.0.0",
+        "merge-source-map": "^1.1.0",
+        "schema-utils": "^2.7.0"
+      }
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader/node_modules/istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader/node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader/node_modules/schema-utils": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.5",
+        "ajv": "^6.12.4",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@jsdevtools/coverage-istanbul-loader/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -8263,9 +8375,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.1.1.tgz",
-      "integrity": "sha512-d5qimadRAUCO4A/Txw71VM7UrRZzV+NPclxz/dc+M6B2oYwjWTjqh8HA/sGQgs9VZuJ6I/P7XIAlJvgrl27ZOw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.2.0.tgz",
+      "integrity": "sha512-rCNLSB/JzNvot0SEyXqWZ7tX2B5dD2a1br2Dp0vSYVo5jh8Z0EZ7lS9TsZ1UtziddB1UfNUaMCc538/HztnJGA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11003,6 +11115,48 @@
       },
       "peerDependencies": {
         "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-coverage": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-coverage/-/addon-coverage-1.0.5.tgz",
+      "integrity": "sha512-EMa5vMJFVZJjp6MKJUa/aAfaw833eQ8/y6BHB2sMnvdwztV9DHMGtA1fXAPFwqOo81q8og0+7e47z1oHPsbk4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.1.0",
+        "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.4",
+        "convert-source-map": "^2.0.0",
+        "espree": "^9.6.1",
+        "istanbul-lib-instrument": "^6.0.1",
+        "test-exclude": "^6.0.0",
+        "vite-plugin-istanbul": "^3.0.1"
+      }
+    },
+    "node_modules/@storybook/addon-coverage/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/addon-coverage/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@storybook/addon-docs": {
@@ -15576,6 +15730,78 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concurrently": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.2.tgz",
+      "integrity": "sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -18148,9 +18374,9 @@
       }
     },
     "node_modules/firebase": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.8.0.tgz",
-      "integrity": "sha512-zIv11czOqFayPllaJySKIKB2pS+xoWOnfI7j85SOiBKY1IW3NuZIaL+UgsZA+4PQZkPhFP8vmU2/oOun04ALbg==",
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.8.1.tgz",
+      "integrity": "sha512-oetXhPCvJZM4DVL/n/06442emMU+KzM0JLZjszpwlU6mqdFZqBwumBxn6hQkLukJyU5wsjihZHUY8HEAE2micg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/ai": "1.3.0",
@@ -18161,15 +18387,15 @@
         "@firebase/app-check-compat": "0.3.25",
         "@firebase/app-compat": "0.4.0",
         "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.10.5",
-        "@firebase/auth-compat": "0.5.25",
-        "@firebase/data-connect": "0.3.8",
-        "@firebase/database": "1.0.18",
-        "@firebase/database-compat": "2.0.9",
-        "@firebase/firestore": "4.7.15",
-        "@firebase/firestore-compat": "0.3.50",
-        "@firebase/functions": "0.12.7",
-        "@firebase/functions-compat": "0.3.24",
+        "@firebase/auth": "1.10.6",
+        "@firebase/auth-compat": "0.5.26",
+        "@firebase/data-connect": "0.3.9",
+        "@firebase/database": "1.0.19",
+        "@firebase/database-compat": "2.0.10",
+        "@firebase/firestore": "4.7.16",
+        "@firebase/firestore-compat": "0.3.51",
+        "@firebase/functions": "0.12.8",
+        "@firebase/functions-compat": "0.3.25",
         "@firebase/installations": "0.6.17",
         "@firebase/installations-compat": "0.2.17",
         "@firebase/messaging": "0.12.21",
@@ -18178,15 +18404,15 @@
         "@firebase/performance-compat": "0.2.19",
         "@firebase/remote-config": "0.6.4",
         "@firebase/remote-config-compat": "0.2.17",
-        "@firebase/storage": "0.13.11",
-        "@firebase/storage-compat": "0.3.21",
+        "@firebase/storage": "0.13.12",
+        "@firebase/storage-compat": "0.3.22",
         "@firebase/util": "1.12.0"
       }
     },
     "node_modules/firebase/node_modules/@firebase/auth": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.5.tgz",
-      "integrity": "sha512-6wF/NdMTwObL4RNQePunuzMr9O3gyftisvFZFFKf57D2HONXo87YymogRV8d+Z7SLA0rcNBN1gLJVk2D0y97gA==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.6.tgz",
+      "integrity": "sha512-cFbo2FymQltog4atI9cKTO6CxKxS0dOMXslTQrlNZRH7qhDG44/d7QeI6GXLweFZtrnlecf52ESnNz1DU6ek8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -21268,6 +21494,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jest-process-manager/node_modules/wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -23094,6 +23340,26 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/merge-source-map/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/merge-stream": {
@@ -31285,6 +31551,46 @@
         }
       }
     },
+    "node_modules/vite-plugin-istanbul": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-istanbul/-/vite-plugin-istanbul-3.0.4.tgz",
+      "integrity": "sha512-DJy3cq6yOFbsM3gLQf/3zeuaJNJsfBv5dLFdZdv8sUV30xLtZI+66QeYfHUyP/5vBUYyLA+xNUCSG5uHY6w+5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.1.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "picocolors": "^1.0.0",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "node_modules/vite-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vite-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
@@ -31299,17 +31605,17 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.3.tgz",
+      "integrity": "sha512-nQFqAFzZDeRxsu7S3C7LbuxslHhk+gnJZHyethuGKAn2IVleIbTB9I3vJSQiSR+DifUqmdzfPMoMPJfLqMF2vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
+        "axios": "^1.8.2",
+        "joi": "^17.13.3",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2"
       },
       "bin": {
         "wait-on": "bin/wait-on"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "localize": "nx run my-personal-project:build:production --localize && npx serve dist/apps/my-personal-project/browser",
     "deploy": "npx nx run my-personal-project:build --configuration=production && firebase deploy",
     "analyze-bundle": "npx nx run my-personal-project:build:analyze-bundle && source-map-explorer dist/apps/my-personal-project/**/*.js --html analyze-bundle.html",
-    "run-before-pr": "npx nx affected -t lint test build e2e"
+    "run-before-pr": "npx nx affected -t lint test build e2e",
+    "test-storybook:ci-not-working": "https://github.com/storybookjs/test-runner?tab=readme-ov-file#getting-started",
+    "test-storybook:local": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"nx run shared/ui:storybook\" \"wait-on tcp:4400 && npx nx run shared/ui:test-storybook\""
   },
   "private": true,
   "dependencies": {
@@ -52,6 +54,7 @@
     "@nx/workspace": "21.1.0",
     "@playwright/test": "^1.36.0",
     "@schematics/angular": "19.2.9",
+    "@storybook/addon-coverage": "1.0.5",
     "@storybook/addon-essentials": "8.6.14",
     "@storybook/addon-interactions": "8.6.14",
     "@storybook/angular": "8.6.14",
@@ -69,9 +72,11 @@
     "angular-eslint": "19.4.0",
     "autoprefixer": "^10.4.0",
     "chromatic": "^11.16.1",
+    "concurrently": "9.1.2",
     "eslint": "^9.8.0",
     "eslint-config-prettier": "10.1.5",
     "eslint-plugin-playwright": "^1.6.2",
+    "http-server": "14.1.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-preset-angular": "14.4.2",
@@ -90,6 +95,7 @@
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",
     "typescript": "5.7.3",
-    "typescript-eslint": "^8.13.0"
+    "typescript-eslint": "^8.13.0",
+    "wait-on": "8.0.3"
   }
 }


### PR DESCRIPTION
- Added '@storybook/addon-coverage' to Storybook addons in main.ts
- Updated test-storybook command in project.json to include coverage option
- Updated package-lock.json with new dependencies and versions
- Updated package.json to include new dependencies: '@storybook/addon-coverage', 'concurrently', 'http-server', and 'wait-on'