### PR TITLE
docs: update stale Angular 19 references to Angular 20

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,12 +1,12 @@
 ---
 name: code-reviewer
-description: Expert Angular/Nx code reviewer specializing in this project's architecture. Checks for Conventional Commits compliance, @mpp/* import correctness, Nx module boundaries, Angular 19 patterns (standalone, OnPush, signals), TypeScript strictness (no-any), testing coverage, and Firebase/Firestore integration.
+description: Expert Angular/Nx code reviewer specializing in this project's architecture. Checks for Conventional Commits compliance, @mpp/* import correctness, Nx module boundaries, Angular 20 patterns (standalone, OnPush, signals), TypeScript strictness (no-any), testing coverage, and Firebase/Firestore integration.
 tools: Read, Bash
 ---
 
 # Code Reviewer Agent
 
-Expert code reviewer specialized in this project's tech stack and conventions: Angular 19 standalone components, Nx monorepo with module boundaries, NgRx Signals, Firebase integration, Tailwind CSS V4, and strict TypeScript.
+Expert code reviewer specialized in this project's tech stack and conventions: Angular 20 standalone components, Nx monorepo with module boundaries, NgRx Signals, Firebase integration, Tailwind CSS V4, and strict TypeScript.
 
 ## Review Checklist
 
@@ -24,7 +24,7 @@ Expert code reviewer specialized in this project's tech stack and conventions: A
 - [ ] Services in data-access, components in feature-* folders
 - [ ] New libraries tagged correctly in project.json
 
-### Angular 19 & Components
+### Angular 20 & Components
 - [ ] Components use `standalone: true`
 - [ ] `ChangeDetectionStrategy.OnPush` set on all components
 - [ ] Dependency injection via `inject()` function, not constructor
@@ -165,7 +165,7 @@ Expert code reviewer specialized in this project's tech stack and conventions: A
 
 ## Resources
 
-- [Angular 19 Docs](https://angular.dev)
+- [Angular 20 Docs](https://angular.dev)
 - [Nx Documentation](https://nx.dev)
 - [Conventional Commits](https://www.conventionalcommits.org/)
 - [TypeScript Handbook](https://www.typescriptlang.org/docs/)

--- a/.claude/agents/test-developer.md
+++ b/.claude/agents/test-developer.md
@@ -1,12 +1,12 @@
 ---
 name: test-developer
-description: Expert test developer for Angular 19 components and services. Specializes in Jest unit tests, Playwright e2e, Storybook documentation, Testing Trophy philosophy (unit > integration > e2e), and comprehensive coverage strategies.
+description: Expert test developer for Angular 20 components and services. Specializes in Jest unit tests, Playwright e2e, Storybook documentation, Testing Trophy philosophy (unit > integration > e2e), and comprehensive coverage strategies.
 tools: Read, Bash, Write, Edit
 ---
 
 # Test Developer Agent
 
-Expert test developer specializing in comprehensive testing strategies for this Angular 19 + Nx monorepo project. Uses the Testing Trophy philosophy: lots of unit tests, some integration tests, a few e2e tests.
+Expert test developer specializing in comprehensive testing strategies for this Angular 20 + Nx monorepo project. Uses the Testing Trophy philosophy: lots of unit tests, some integration tests, a few e2e tests.
 
 ## Testing Philosophy: The Testing Trophy
 

--- a/.claude/rules/nx-boundaries.md
+++ b/.claude/rules/nx-boundaries.md
@@ -8,7 +8,7 @@ description: Nx monorepo structure, module tagging scheme, and dependency bounda
 ## Monorepo Structure (Nx 21.1.0)
 
 ### Apps
-- `apps/my-personal-project` — Main Angular 19 application
+- `apps/my-personal-project` — Main Angular 20 application
 - `apps/my-personal-project-e2e` — Playwright e2e test suite for the main app
 
 ### Libraries

--- a/.claude/skills/angular-jest-unit-testing/SKILL.md
+++ b/.claude/skills/angular-jest-unit-testing/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Expert Angular 19 unit testing with Jest for shared libraries. Write comprehensive specs for components (TestBed, fixture detection, async, ChangeDetectionStrategy.OnPush), services (injection, observables, mocks), directives, and utilities. Use when writing tests, debugging test failures, implementing test coverage, testing reactive forms, mocking services, testing observables, or ensuring component behavior verification. Covers Jest setup, mocking strategies, async patterns, snapshot testing, and Angular-specific testing conventions.
+description: Expert Angular 20 unit testing with Jest for shared libraries. Write comprehensive specs for components (TestBed, fixture detection, async, ChangeDetectionStrategy.OnPush), services (injection, observables, mocks), directives, and utilities. Use when writing tests, debugging test failures, implementing test coverage, testing reactive forms, mocking services, testing observables, or ensuring component behavior verification. Covers Jest setup, mocking strategies, async patterns, snapshot testing, and Angular-specific testing conventions.
 ---
 
 # Angular Jest Unit Testing
 
-Expert guide for writing, debugging, and maintaining unit tests for Angular 19 components and services using Jest. Focused on testing shared libraries and monorepo projects with signals, standalone components, and modern patterns.
+Expert guide for writing, debugging, and maintaining unit tests for Angular 20 components and services using Jest. Focused on testing shared libraries and monorepo projects with signals, standalone components, and modern patterns.
 
 ## When to Use This Skill
 
@@ -23,7 +23,7 @@ Expert guide for writing, debugging, and maintaining unit tests for Angular 19 c
 
 ## Prerequisites
 
-- Angular 19.2.9 understanding (standalone components, signals, `inject()`)
+- Angular 20.3.9 understanding (standalone components, signals, `inject()`)
 - Jest fundamentals (`test`, `expect`, `beforeEach`, `afterEach`, mocks)
 - Angular testing utilities: `TestBed`, `ComponentFixture`, `fakeAsync`, `tick`
 - Monorepo structure: `libs/` layout with `@mpp/*` import aliases

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This structure ensures modularity, reusability, and scalability, making it easie
 ```bash
 my-personal-project/
 ├── apps/
-│   ├── my-personal-project/        # Main web application (Angular 19 standalone)
+│   ├── my-personal-project/        # Main web application (Angular 20 standalone)
 │   │   └── src/
 │   │       ├── app/                # Feature modules (cv, scribo, auth)
 │   │       ├── environments/       # Environment configurations


### PR DESCRIPTION
## Summary
- The stack was upgraded to Angular 20.3.9 (logged in `.claude/versions.md`), but several project docs still referenced Angular 19.
- Updated `code-reviewer` and `test-developer` agent definitions, `angular-jest-unit-testing` skill, `nx-boundaries.md` rule, and `README.md` to say Angular 20.

## Test plan
- [x] `grep -rn "Angular 19"` across `.claude/agents`, `.claude/rules`, `.claude/skills/angular-jest-unit-testing`, `README.md` returns no matches
- Docs-only change, no build/test impact