### PR TITLE
test(shared/ui): add dialog coverage and signalize consumer state

### DIFF
--- a/libs/cv/feature-about/src/lib/components/landing/landing.component.html
+++ b/libs/cv/feature-about/src/lib/components/landing/landing.component.html
@@ -22,16 +22,16 @@
         </div>
       }
     </div>
-    @if (dialogOpen) {
+    @if (dialogOpen()) {
       <ui-dialog
-        [isOpen]="dialogOpen"
-        [title]="dialogTitle"
+        [isOpen]="dialogOpen()"
+        [title]="dialogTitle()"
         (confirm)="closeDialog()"
         [confirmButtonText]="'Cerrar'"
         [hideCancelButton]="true"
         >
         <ul class="mt-2 list-inside list-disc text-gray-700 dark:text-gray-400">
-          <li *ngForTranslate="let keyPoint; from: listKey; let keyPointKey = index">
+          <li *ngForTranslate="let keyPoint; from: listKey(); let keyPointKey = index">
             {{ keyPoint }}
           </li>
         </ul>

--- a/libs/cv/feature-about/src/lib/components/landing/landing.component.spec.ts
+++ b/libs/cv/feature-about/src/lib/components/landing/landing.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { DialogComponent } from '@mpp/shared/ui';
 import { NgForTranslateDirective, TranslatePipe, TranslationService } from '@mpp/shared/util-translation';
+import { By } from '@angular/platform-browser';
 import { LandingComponent } from './landing.component';
 import { LandingService } from './landing.service';
 
@@ -13,21 +14,21 @@ describe('LandingComponent', () => {
 
   beforeEach(async () => {
     mockTranslationService = {
-      translate: jest.fn(),
+      translate: jest.fn((key: string) => `translated:${key}`),
       getTranslations: jest.fn(),
     };
 
     await TestBed.configureTestingModule({
       imports: [
         LandingComponent,
-        DialogComponent, // Add necessary imports
+        DialogComponent,
         TranslatePipe,
         NgForTranslateDirective,
       ],
       providers: [
         { provide: TranslationService, useValue: mockTranslationService },
-        LandingService, //Provide LandingService
-        { provide: ActivatedRoute, useValue: {} }, // Provide ActivatedRoute mock
+        LandingService,
+        { provide: ActivatedRoute, useValue: {} },
       ],
     }).compileComponents();
 
@@ -38,5 +39,56 @@ describe('LandingComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should start with the dialog closed and default state', () => {
+    // Assert
+    expect(component.dialogOpen()).toBe(false);
+    expect(component.dialogTitle()).toBeUndefined();
+    expect(component.listKey()).toBe('');
+    expect(fixture.debugElement.query(By.directive(DialogComponent))).toBeNull();
+  });
+
+  describe('openDialog', () => {
+    it('should set the dialog signals from the given experience and listKey', () => {
+      // Act
+      component.openDialog('cv.landing.jobs.0.title', 'cv.landing.jobs.0.key-points');
+
+      // Assert
+      expect(mockTranslationService.translate).toHaveBeenCalledWith('cv.landing.jobs.0.title');
+      expect(component.dialogTitle()).toBe('translated:cv.landing.jobs.0.title');
+      expect(component.listKey()).toBe('cv.landing.jobs.0.key-points');
+      expect(component.dialogOpen()).toBe(true);
+    });
+
+    it('should render the ui-dialog with the bound state once opened', () => {
+      // Act
+      component.openDialog('cv.landing.jobs.0.title', 'cv.landing.jobs.0.key-points');
+      fixture.detectChanges();
+
+      // Assert
+      const dialogDebugEl = fixture.debugElement.query(By.directive(DialogComponent));
+      expect(dialogDebugEl).toBeTruthy();
+      const dialog = dialogDebugEl.componentInstance as DialogComponent;
+      expect(dialog.isOpen()).toBe(true);
+      expect(dialog.title()).toBe('translated:cv.landing.jobs.0.title');
+    });
+  });
+
+  describe('closeDialog', () => {
+    it('should close the dialog and remove the ui-dialog from the DOM', () => {
+      // Arrange
+      component.openDialog('cv.landing.jobs.0.title', 'cv.landing.jobs.0.key-points');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.directive(DialogComponent))).toBeTruthy();
+
+      // Act
+      component.closeDialog();
+      fixture.detectChanges();
+
+      // Assert
+      expect(component.dialogOpen()).toBe(false);
+      expect(fixture.debugElement.query(By.directive(DialogComponent))).toBeNull();
+    });
   });
 });

--- a/libs/cv/feature-about/src/lib/components/landing/landing.component.ts
+++ b/libs/cv/feature-about/src/lib/components/landing/landing.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { DialogComponent, IconComponent } from '@mpp/shared/ui';
 import { LandingService } from './landing.service';
@@ -20,18 +20,18 @@ export class LandingComponent {
   private readonly translationService = inject(TranslationService);
   private readonly router = inject(Router);
 
-  dialogOpen = false;
-  dialogTitle: string | undefined;
-  listKey = '';
+  readonly dialogOpen = signal(false);
+  readonly dialogTitle = signal<string | undefined>(undefined);
+  readonly listKey = signal('');
 
   openDialog(experience: string, listKey: string) {
-    this.dialogTitle = this.translationService.translate(experience);
-    this.listKey = listKey;
-    this.dialogOpen = true;
+    this.dialogTitle.set(this.translationService.translate(experience));
+    this.listKey.set(listKey);
+    this.dialogOpen.set(true);
   }
 
   closeDialog() {
-    this.dialogOpen = false;
+    this.dialogOpen.set(false);
   }
 
   onCLickScriboProject() {

--- a/libs/shared/ui/src/lib/components/atoms/dialog/dialog.component.spec.ts
+++ b/libs/shared/ui/src/lib/components/atoms/dialog/dialog.component.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DialogComponent } from './dialog.component';
+
+describe('DialogComponent', () => {
+  let component: DialogComponent;
+  let fixture: ComponentFixture<DialogComponent>;
+
+  beforeEach(async () => {
+    // Arrange
+    await TestBed.configureTestingModule({
+      imports: [DialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('default input values', () => {
+    it('should default confirmButtonText to "Confirm"', () => {
+      expect(component.confirmButtonText()).toBe('Confirm');
+    });
+
+    it('should default cancelButtonText to "Cancel"', () => {
+      expect(component.cancelButtonText()).toBe('Cancel');
+    });
+
+    it('should default isOpen to true', () => {
+      expect(component.isOpen()).toBe(true);
+    });
+
+    it('should default cancelButtonDisabled to false', () => {
+      expect(component.cancelButtonDisabled()).toBe(false);
+    });
+
+    it('should default hideCancelButton to false', () => {
+      expect(component.hideCancelButton()).toBe(false);
+    });
+
+    it('should default confirmButtonDisabled to false', () => {
+      expect(component.confirmButtonDisabled()).toBe(false);
+    });
+  });
+
+  describe('visibility (isOpen)', () => {
+    it('should render the dialog content when isOpen is true', () => {
+      // Arrange
+      fixture.componentRef.setInput('isOpen', true);
+      // Act
+      fixture.detectChanges();
+      // Assert
+      const overlay = fixture.debugElement.query(By.css('div'));
+      expect(overlay).toBeTruthy();
+      const buttons = fixture.debugElement.queryAll(By.css('button'));
+      expect(buttons.length).toBe(2);
+    });
+
+    it('should not render the dialog content when isOpen is false', () => {
+      // Arrange
+      fixture.componentRef.setInput('isOpen', false);
+      // Act
+      fixture.detectChanges();
+      // Assert
+      const overlay = fixture.debugElement.query(By.css('div'));
+      expect(overlay).toBeNull();
+    });
+  });
+
+  describe('title', () => {
+    it('should render the provided title', () => {
+      // Arrange
+      fixture.componentRef.setInput('title', 'My Dialog Title');
+      // Act
+      fixture.detectChanges();
+      // Assert
+      const heading = fixture.debugElement.query(By.css('h2'));
+      expect(heading.nativeElement.textContent).toContain('My Dialog Title');
+    });
+  });
+
+  describe('confirm output', () => {
+    it('should emit confirm when the confirm button is clicked', () => {
+      // Arrange
+      const emitSpy = jest.spyOn(component.confirm, 'emit');
+      fixture.detectChanges();
+      const confirmButton = fixture.debugElement.queryAll(By.css('button'))[0];
+      // Act
+      confirmButton.nativeElement.click();
+      // Assert
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('closed output', () => {
+    it('should emit closed when the cancel button is clicked', () => {
+      // Arrange
+      const emitSpy = jest.spyOn(component.closed, 'emit');
+      fixture.detectChanges();
+      const cancelButton = fixture.debugElement.queryAll(By.css('button'))[1];
+      // Act
+      cancelButton.nativeElement.click();
+      // Assert
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cancel button', () => {
+    it('should hide the cancel button when hideCancelButton is true', () => {
+      // Arrange
+      fixture.componentRef.setInput('hideCancelButton', true);
+      // Act
+      fixture.detectChanges();
+      // Assert
+      const buttons = fixture.debugElement.queryAll(By.css('button'));
+      expect(buttons.length).toBe(1);
+    });
+
+    it('should disable the cancel button when cancelButtonDisabled is true', () => {
+      // Arrange
+      fixture.componentRef.setInput('cancelButtonDisabled', true);
+      // Act
+      fixture.detectChanges();
+      // Assert
+      const cancelButton = fixture.debugElement.queryAll(By.css('button'))[1];
+      expect(cancelButton.nativeElement.disabled).toBe(true);
+    });
+  });
+
+  describe('confirm button', () => {
+    it('should disable the confirm button when confirmButtonDisabled is true', () => {
+      // Arrange
+      fixture.componentRef.setInput('confirmButtonDisabled', true);
+      // Act
+      fixture.detectChanges();
+      // Assert
+      const confirmButton = fixture.debugElement.queryAll(By.css('button'))[0];
+      expect(confirmButton.nativeElement.disabled).toBe(true);
+    });
+
+    it('should render the provided confirmButtonText', () => {
+      // Arrange
+      fixture.componentRef.setInput('confirmButtonText', 'Save');
+      // Act
+      fixture.detectChanges();
+      // Assert
+      const confirmButton = fixture.debugElement.queryAll(By.css('button'))[0];
+      expect(confirmButton.nativeElement.textContent).toContain('Save');
+    });
+  });
+});


### PR DESCRIPTION
Closes #77

## Summary
- Add `dialog.component.spec.ts` covering defaults, visibility toggling, title, confirm/closed output emission, and cancel/confirm disabled/hide states
- Convert `LandingComponent` dialog state (`dialogOpen`, `dialogTitle`, `listKey`) to `signal()` state and update template bindings
- Expand `landing.component.spec.ts` to exercise `openDialog`/`closeDialog` and assert rendered `ui-dialog` state

## Test plan
- `nx test shared/ui` — 4 suites / 37 tests passed
- `nx test cv/feature-about` — 1 suite / 5 tests passed
- `nx lint shared/ui` / `nx lint cv/feature-about` — 0 errors (pre-existing warnings only, none in changed files)
- `nx build shared/ui` and `nx build my-personal-project` — both succeed

Generated with [Claude Code](https://claude.ai/code)